### PR TITLE
[Feat] 내가 작성한/좋아한 게시물 조회 등 유저 기능 구현

### DIFF
--- a/config/baseResponseStatus.js
+++ b/config/baseResponseStatus.js
@@ -133,7 +133,7 @@ module.exports = {
   USER_NICKNAME_EMPTY: {
     isSuccess: false,
     code: 2017,
-    message: '변경할 닉네임 값을 입력해주세요',
+    message: '닉네임 값을 입력해주세요',
   },
 
   USER_STATUS_EMPTY: {

--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -151,6 +151,42 @@ exports.deleteUser = async function (req, res) {
   return res.send(deleteUser);
 };
 
+exports.getUserLikedReview = async function (req, res) {
+  const USER_IDX = req.user_idx;
+
+  const userLikedReview = await userProvider.getUserLikedReview(USER_IDX);
+  return res.send(userLikedReview);
+};
+
+exports.getUserWrittenReview = async function (req, res) {
+  const USER_IDX = req.user_idx;
+
+  const userWrittenReview = await userProvider.getUserWrittenReview(USER_IDX);
+  return res.send(userWrittenReview);
+};
+
+//TODO: 필요 여부 미정
+// exports.getUserLikedMenu = async function (req, res) {
+//   const USER_IDX = req.user_idx;
+
+//   const userLikedMenu = await userProvider.getUserLikedMenu(USER_IDX);
+//   return res.send(userLikedMenu);
+// };
+
+// exports.getUserLikedReport = async function (req, res) {
+//   const USER_IDX = req.user_idx;
+
+//   const userLikedReport = await userProvider.getUserLikedReport(USER_IDX);
+//   return res.send(userLikedReport);
+// };
+
+// exports.getUserWrittenReport = async function (req, res) {
+//   const USER_IDX = req.user_idx;
+
+//   const userWrittenReport = await userProvider.getUserWrittenReport(USER_IDX);
+//   return res.send(userWrittenReport);
+// };
+
 exports.test = function (req, res) {
   const userIdxFromJWT = req.user_idx;
   console.log(userIdxFromJWT);

--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -139,6 +139,11 @@ exports.changeName = async function (req, res) {
   return res.send(editUserNickname);
 };
 
+exports.deleteUser = async function (req, res) {
+  const deleteUser = await userService.deleteUser(req.user_idx);
+  return res.send(deleteUser);
+};
+
 exports.test = function (req, res) {
   const userIdxFromJWT = req.user_idx;
   console.log(userIdxFromJWT);

--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -121,6 +121,17 @@ exports.findPassword = async function (req, res) {
   return res.send(result);
 };
 
+exports.checkNicknameExist = async function (req, res) {
+  const CHECK_NICKNAME = req.query.nickname;
+  if (!CHECK_NICKNAME)
+    return res.send(errResponse(baseResponse.USER_NICKNAME_EMPTY));
+
+  const checkUserNickname = await userProvider.checkNicknameExist(
+    CHECK_NICKNAME
+  );
+  return res.send(checkUserNickname);
+};
+
 /**
  * API No. ?
  * API Name : 회원 정보 수정 API + JWT

--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -139,6 +139,13 @@ exports.changeName = async function (req, res) {
   return res.send(editUserNickname);
 };
 
+exports.getUserLevel = async function (req, res) {
+  const USER_IDX = req.user_idx;
+
+  const newAccessToken = await userProvider.getUserLevel(USER_IDX);
+  return res.send(newAccessToken);
+};
+
 exports.deleteUser = async function (req, res) {
   const deleteUser = await userService.deleteUser(req.user_idx);
   return res.send(deleteUser);

--- a/src/app/User/userDao.js
+++ b/src/app/User/userDao.js
@@ -54,6 +54,19 @@ async function selectUserAndStatByNickname(connection, nickname) {
   return studentIdRows;
 }
 
+async function countNickname(connection, nickname) {
+  const countNicknameQuery = `
+  SELECT COUNT(User.nickname) AS number
+  FROM User
+  WHERE User.nickname = BINARY(?)`;
+
+  const [countNicknameNumber] = await connection.query(
+    countNicknameQuery,
+    nickname
+  );
+  return countNicknameNumber[0].number;
+}
+
 async function selectLoginUserStudentId(connection, student_id) {
   const selectLoginUserStudentIdQuery = `
                  SELECT user_idx, pw, stat, token
@@ -205,6 +218,7 @@ module.exports = {
   selectUserAndStatByUserIdx,
   selectLoginUserStudentId,
   selectUserAndStatByNickname,
+  countNickname,
   insertUserInfo,
   updateUserNickname,
   setUserStateDisable,

--- a/src/app/User/userDao.js
+++ b/src/app/User/userDao.js
@@ -149,6 +149,56 @@ async function selectUserPoint(connection, userIdx) {
   return userRTokenInfoRows;
 }
 
+async function selectUserLikedReview(connection, userIdx) {
+  const selectUserLikedReviewQuery = `
+                SELECT Review.review_idx, Review.store_idx, Store.name AS store_name, Review.content, Review.likes, Review.unlikes, Review.image_url
+                FROM Review
+
+                  JOIN UserLikedReview
+                  ON Review.review_idx = UserLikedReview.review_idx
+
+                  JOIN Store
+                  ON Review.store_idx = Store.store_idx
+
+                WHERE UserLikedReview.user_idx = ?;
+                `;
+  const [userUserLikedReviewRows] = await connection.query(
+    selectUserLikedReviewQuery,
+    userIdx
+  );
+  return userUserLikedReviewRows;
+}
+
+async function selectUserWrittenReview(connection, userIdx) {
+  const selectUserWrittenReviewQuery = `
+                SELECT Review.review_idx, Review.store_idx, Store.name AS store_name, Review.content, Review.likes, Review.unlikes, Review.image_url
+                FROM Review
+                  JOIN Store
+                  ON Review.store_idx = Store.store_idx
+                WHERE Review.user_idx = ?;
+                `;
+  const [userUserWrittenReviewRows] = await connection.query(
+    selectUserWrittenReviewQuery,
+    userIdx
+  );
+  return userUserWrittenReviewRows;
+}
+
+async function selectMenusByReview(connection, review_idx) {
+  const menusByReviewQuery = `
+                SELECT Menu.menu_idx, Menu.menu_name
+                FROM Menu 
+                  JOIN  ReviewMenu
+                  ON ReviewMenu.menu_idx = Menu.menu_idx
+                WHERE ReviewMenu.review_idx = ?;
+                `;
+  const [MenusByReview] = await connection.query(
+    menusByReviewQuery,
+    review_idx
+  );
+  return MenusByReview;
+}
+
 module.exports = {
   selectUserStudentId,
   selectUserAndStatByStudentId,
@@ -162,4 +212,7 @@ module.exports = {
   updateUserPassword,
   selectRefreshTokenUseUserIdx,
   selectUserPoint,
+  selectUserLikedReview,
+  selectUserWrittenReview,
+  selectMenusByReview,
 };

--- a/src/app/User/userDao.js
+++ b/src/app/User/userDao.js
@@ -136,6 +136,19 @@ async function selectRefreshTokenUseUserIdx(connection, userIdx) {
   return userRTokenInfoRows;
 }
 
+async function selectUserPoint(connection, userIdx) {
+  const selectUserRefreshTokenQuery = `
+                SELECT user_idx, level_times
+                FROM User 
+                WHERE user_idx = ?;
+                `;
+  const [userRTokenInfoRows] = await connection.query(
+    selectUserRefreshTokenQuery,
+    userIdx
+  );
+  return userRTokenInfoRows;
+}
+
 module.exports = {
   selectUserStudentId,
   selectUserAndStatByStudentId,
@@ -148,4 +161,5 @@ module.exports = {
   updateUserToken,
   updateUserPassword,
   selectRefreshTokenUseUserIdx,
+  selectUserPoint,
 };

--- a/src/app/User/userDao.js
+++ b/src/app/User/userDao.js
@@ -93,6 +93,15 @@ async function updateUserNickname(connection, user_idx, newNickname) {
   return updateUserRow[0];
 }
 
+async function setUserStateDisable(connection, user_idx) {
+  const updateUserQuery = `
+  UPDATE User 
+  SET stat = 'D'
+  WHERE user_idx = ?;`;
+  const updateUserRow = await connection.query(updateUserQuery, user_idx);
+  return updateUserRow[0];
+}
+
 async function updateUserPassword(connection, id, password) {
   const updateUserQuery = `
   UPDATE User
@@ -135,6 +144,7 @@ module.exports = {
   selectUserAndStatByNickname,
   insertUserInfo,
   updateUserNickname,
+  setUserStateDisable,
   updateUserToken,
   updateUserPassword,
   selectRefreshTokenUseUserIdx,

--- a/src/app/User/userProvider.js
+++ b/src/app/User/userProvider.js
@@ -63,3 +63,17 @@ exports.refreshTokenWithUserIdx = async function (rToken, userIdx) {
     access_token: NEW_ACCESS_TOKEN,
   });
 };
+
+exports.getUserLevel = async function (userIdx) {
+  const connection = await pool.getConnection(async (conn) => conn);
+  const userPointQuery = await userDao.selectUserPoint(connection, userIdx);
+  connection.release();
+
+  const userPoint = userPointQuery[0].level_times;
+
+  //TODO: 마이페이지 등급 조회
+
+  return response(baseResponseStatus.SUCCESS, {
+    times: userPoint,
+  });
+};

--- a/src/app/User/userProvider.js
+++ b/src/app/User/userProvider.js
@@ -5,6 +5,7 @@ const { logger } = require('../../../config/winston');
 const { verifyRToken, signAToken } = require('../../../util/jwtUtil');
 
 const userDao = require('./userDao');
+const userUtil = require('./userUtil');
 
 // Provider: Read 비즈니스 로직 처리
 exports.studentIdCheck = async function (student_id) {
@@ -75,5 +76,67 @@ exports.getUserLevel = async function (userIdx) {
 
   return response(baseResponseStatus.SUCCESS, {
     times: userPoint,
+  });
+};
+
+exports.getUserLikedReview = async function (userIndex) {
+  const conn = await pool.getConnection(async (conn) => conn);
+  const userLikedReviews = [];
+
+  //리뷰 내용 가져오기
+  const likedReviewsContent = await userDao.selectUserLikedReview(
+    conn,
+    userIndex
+  );
+
+  for (let i = 0; i < likedReviewsContent.length; i++) {
+    const reviewContent = likedReviewsContent[i];
+
+    //해당 리뷰 메뉴 가져오기
+    const menusInReview = await userUtil.collectMenusList(conn, reviewContent);
+
+    // 반환할 리뷰글 형식 만들기
+    const reviewDetail = await userUtil.formatReviewDate(
+      reviewContent,
+      menusInReview
+    );
+
+    userLikedReviews.push(reviewDetail);
+  }
+  conn.release();
+
+  return response(baseResponseStatus.SUCCESS, {
+    reviews: userLikedReviews,
+  });
+};
+
+exports.getUserWrittenReview = async function (userIndex) {
+  const conn = await pool.getConnection(async (conn) => conn);
+  const userWrittenReviews = [];
+
+  //리뷰 내용 가져오기
+  const writtenReviewsContent = await userDao.selectUserWrittenReview(
+    conn,
+    userIndex
+  );
+
+  for (let i = 0; i < writtenReviewsContent.length; i++) {
+    const reviewContent = writtenReviewsContent[i];
+
+    //해당 리뷰 메뉴 가져오기
+    const menusInReview = await userUtil.collectMenusList(conn, reviewContent);
+
+    // 반환할 리뷰글 형식 만들기
+    const reviewDetail = await userUtil.formatReviewDate(
+      reviewContent,
+      menusInReview
+    );
+
+    userWrittenReviews.push(reviewDetail);
+  }
+  conn.release();
+
+  return response(baseResponseStatus.SUCCESS, {
+    reviews: userWrittenReviews,
   });
 };

--- a/src/app/User/userProvider.js
+++ b/src/app/User/userProvider.js
@@ -19,6 +19,16 @@ exports.studentIdCheck = async function (student_id) {
   return StudentIdCheckResult;
 };
 
+exports.checkNicknameExist = async function (new_nickname) {
+  const conn = await pool.getConnection(async (conn) => conn);
+  const nicknameNumber = await userDao.countNickname(conn, new_nickname);
+  if (nicknameNumber === 0) {
+    return response(baseResponseStatus.SUCCESS);
+  } else {
+    return errResponse(baseResponseStatus.SIGNUP_REDUNDANT_NICKNAME);
+  }
+};
+
 exports.userStatCheckBySchoolId = async function (student_id) {
   const connection = await pool.getConnection(async (conn) => conn);
   const studentIdCheckResult = await userDao.selectUserAndStatByStudentId(

--- a/src/app/User/userRoute.js
+++ b/src/app/User/userRoute.js
@@ -24,4 +24,6 @@ module.exports = function (app) {
   app.patch('/app/user/changeName', verifyAToken, user.changeName);
 
   app.patch('/app/user/:userId', user.patchUsers);
+
+  app.delete('/app/user', verifyAToken, user.deleteUser);
 };

--- a/src/app/User/userRoute.js
+++ b/src/app/User/userRoute.js
@@ -25,6 +25,17 @@ module.exports = function (app) {
 
   app.patch('/app/user/changeName', verifyAToken, user.changeName);
 
+  app.get('/app/user/likedReview', verifyAToken, user.getUserLikedReview);
+
+  app.get('/app/user/writtenReview', verifyAToken, user.getUserWrittenReview);
+
+  //TODO: 필요 여부 미정
+  // app.get('/app/user/likedReport', verifyAToken, user.getUserLikedReport);
+
+  // app.get('/app/user/likedMenu', verifyAToken, user.getUserLikedMenu);
+
+  // app.get('/app/user/writtenReport', verifyAToken, user.getUserWrittenReport);
+
   app.patch('/app/user/:userId', user.patchUsers);
 
   app.delete('/app/user', verifyAToken, user.deleteUser);

--- a/src/app/User/userRoute.js
+++ b/src/app/User/userRoute.js
@@ -17,6 +17,8 @@ module.exports = function (app) {
   //Access Token 인증 예제
   app.get('/app/user/test', verifyAToken, user.test);
 
+  app.get('/app/user/info', verifyAToken, user.getUserLevel);
+
   app.get('/app/user/refresh', verifyAToken, user.refreshJWT);
 
   app.post('/app/user/tempPW', user.findPassword);

--- a/src/app/User/userRoute.js
+++ b/src/app/User/userRoute.js
@@ -8,6 +8,9 @@ module.exports = function (app) {
   // 0. 테스트 API
   // app.get('/app/test', user.getTest)
 
+  // 유저 닉네임 중복체크 API
+  app.get('/app/user/checkNickname', user.checkNicknameExist);
+
   // 1. 유저 생성 (회원가입) API
   app.post('/app/user/register', user.postUsers);
 

--- a/src/app/User/userService.js
+++ b/src/app/User/userService.js
@@ -183,6 +183,18 @@ exports.editUserNickname = async function (userIdx, newNickname) {
   }
 };
 
+exports.deleteUser = async function (userIdx) {
+  try {
+    var connection = await pool.getConnection(async (conn) => conn);
+    await userDao.setUserStateDisable(connection, userIdx);
+    connection.release();
+    return response(baseResponse.SUCCESS);
+  } catch (err) {
+    logger.error(`App - deleteUser Service error\n: ${err.message}`);
+    return errResponse(baseResponse.DB_ERROR);
+  }
+};
+
 exports.editUser = async function (id, nickname) {
   try {
     console.log(id);

--- a/src/app/User/userUtil.js
+++ b/src/app/User/userUtil.js
@@ -1,0 +1,28 @@
+const userDao = require('./userDao');
+
+exports.collectMenusList = async function (connection, reviewContent) {
+  const reviewIndex = reviewContent.review_idx;
+  const menuList = await userDao.selectMenusByReview(connection, reviewIndex);
+
+  const menuDetailList = [];
+  for (let i = 0; i < menuList.length; i++) {
+    const nowMenu = menuList[i];
+    menuDetailList.push({
+      menu_name: nowMenu.menu_name,
+      menu_index: nowMenu.menu_idx,
+    });
+  }
+  return menuDetailList;
+};
+
+//미아페이지 게시글 형식 반환
+exports.formatReviewDate = function (reviewContent, menuList) {
+  return {
+    store_name: reviewContent.store_name,
+    review_body: reviewContent.content,
+    image_number: 9, //TODO: 이미지 사진 관련 업데이트 필요
+    like_number: reviewContent.likes,
+    unlike_number: reviewContent.unlikes,
+    menus: menuList,
+  };
+};


### PR DESCRIPTION
## 내가 작성한/좋아한 게시물 조회하기
이외에도 API 명세서의 유저 기능안에 "내가 좋아/작성한 메뉴/제보글 조회"가 있지만, 피그마에 해당 화면을 찾지 못해서 일단 하지 않았는데, 필요하면 또 만들겠습니다. 

## 닉네임 중복 검사
이 기능은 반대로 API명세서에 없지만 피그마에 보여서 만들었습니다. 

## 마이페이지 등급 조회
이거는 일단 작성한 리뷰 수만 반환하고 있어요. 백엔드에서 정확히 어떤 정보를 반환해야 하는지, 만약에 등급만 반환한다면 각 등급의 기준이 무엇인지 정할 필요가 있어 보입니다. 

## 회원탈퇴 기능
간단하게 작성했습니다. 

관련 이슈: #18 